### PR TITLE
isLoggable() update

### DIFF
--- a/slf4j-timber/src/main/java/org/slf4j/impl/TimberAndroidLoggerAdapter.java
+++ b/slf4j-timber/src/main/java/org/slf4j/impl/TimberAndroidLoggerAdapter.java
@@ -492,7 +492,7 @@ class TimberAndroidLoggerAdapter extends MarkerIgnoringBase {
      * @return always true
      */
     private boolean isLoggable(int priority) {
-        return true;
+        return Timber.treeCount() > 0;
     }
 
     private void logInternal(int priority, String message, Throwable throwable) {

--- a/slf4j-timber/src/test/java/at/favre/lib/slf4j/SimpleLogTest.java
+++ b/slf4j-timber/src/test/java/at/favre/lib/slf4j/SimpleLogTest.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import timber.log.Timber;
 
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 /**
@@ -102,6 +103,16 @@ public class SimpleLogTest {
         assertTrue(logger.isInfoEnabled());
         assertTrue(logger.isWarnEnabled());
         assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void testIsLoggable_noTreesPlanted() {
+        Timber.uprootAll();
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertFalse(logger.isInfoEnabled());
+        assertFalse(logger.isWarnEnabled());
+        assertFalse(logger.isErrorEnabled());
     }
 
     private void testLog(int priority, String message, Throwable t) {


### PR DESCRIPTION
Make `TimberAndroidLoggerAdapter.isLoggable(int)` return `false` if no Timber Trees are planted.

Unfortunately `Timber.Tree.isLoggable()` has `protected` visibility, so I can't use the exact solution proposed in #1. This version does have the benefit of not taking `O(n)` time to determine if each log is loggable.

Some thoughts about how to actually check Timber's loggability in a potential future PR:
* Put a static helper method in the `timber.log` package so it has access to `Timber.Tree.isLoggable()`, and use that to determine loggability on a per-Tree basis.
* Put a static flag in this library that users can set whether they want to bother checking loggability on a per-Tree basis or not. Kind of a meh solution but seems necessary to allow configurability with SLF4J's magic logger instantiation.